### PR TITLE
remove mutable default argument in prototype __deepcopy__ method

### DIFF
--- a/src/Prototype/Conceptual/main.py
+++ b/src/Prototype/Conceptual/main.py
@@ -42,7 +42,7 @@ class SomeComponent:
 
         return new
 
-    def __deepcopy__(self, memo={}):
+    def __deepcopy__(self, memo=None):
         """
         Create a deep copy. This method will be called whenever someone calls
         `copy.deepcopy` with this object and the returned value is returned as
@@ -54,6 +54,8 @@ class SomeComponent:
         to all the `deepcopy` calls you make in the `__deepcopy__` implementation
         to prevent infinite recursions.
         """
+        if memo is None:
+            memo = {}
 
         # First, let's create copies of the nested objects.
         some_list_of_objects = copy.deepcopy(self.some_list_of_objects, memo)


### PR DESCRIPTION
We should not use mutable objects as default arguments in python functions/methods, so I fixed it in the prototype class.

Before the change:
Every time we called the `__deepcopy__` method (actually called by python when you use copy.deepcopy) without the memo argument, the same dict instance was being used. This happens because default arguments are instantiated at *load-module time*. Leads to dangerous behaviour: if you update the dict in some method-call, you will use the same updated dict in another calls.

Now:
The memo dict is created in every call without the memo argument. 

ps: no changes to Output.txt are required