### PR TITLE
Fix unexpected behavior with mutable object as default param in Iterator Pattern

### DIFF
--- a/src/Iterator/Conceptual/main.py
+++ b/src/Iterator/Conceptual/main.py
@@ -87,8 +87,8 @@ class WordsCollection(Iterable):
     получения новых экземпляров итератора, совместимых с классом коллекции.
     """
 
-    def __init__(self, collection: List[Any] = []) -> None:
-        self._collection = collection
+    def __init__(self, collection: List[Any] = None) -> None:
+        self._collection = collection or []
 
     def __iter__(self) -> AlphabeticalOrderIterator:
         """


### PR DESCRIPTION
There is unexpected behavior for the iterator pattern when using some mutable object (list, dict...) as a default parameter, where the same mutable object is referenced in all the instantiated concrete objects.

Before:
```python
>>> collection = WordsCollection()
>>> other_collection = WordsCollection()
>>>
>>> collection.add_item('First')
>>> collection.add_item('Second')
>>> collection.add_item('Third')
>>>
>>> other_collection._collection
['First', 'Second', 'Third']
```

Now:
```python
>>> collection = WordsCollection()
>>> other_collection = WordsCollection()
>>>
>>> collection.add_item('First')
>>> collection.add_item('Second')
>>> collection.add_item('Third')
>>>
>>> other_collection._collection
[]
```

In this way, there is no interference with other objects, as all created collections have their own data structure.

---

more info: 
- https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments
- https://web.archive.org/web/20200221224620id_/http://effbot.org/zone/default-values.htm